### PR TITLE
Changes to loading kubeconfig for API Object

### DIFF
--- a/plugins/chaos/torpedo_chaos/common/driver/kubernetes/base.py
+++ b/plugins/chaos/torpedo_chaos/common/driver/kubernetes/base.py
@@ -27,9 +27,7 @@ urllib3.disable_warnings()
 class Kubernetes(object):
 
     def __init__(self, **kwargs):
-        self.token = kwargs['token']
+        config.load_kube_config()
         conf = client.Configuration()
-        conf.host = kwargs['host']
         conf.verify_ssl = False
-        conf.api_key = {"authorization": "Bearer " + self.token}
         self.api_client = client.ApiClient(conf)

--- a/plugins/chaos/torpedo_chaos/kube_chaos.py
+++ b/plugins/chaos/torpedo_chaos/kube_chaos.py
@@ -18,19 +18,8 @@ formatter = logging.Formatter(
 stream_handle.setFormatter(formatter)
 LOG.addHandler(stream_handle)
 
-cmd = ("kubectl describe secret -n metacontroller $(kubectl get secrets"
-       " -n metacontroller | grep ^resiliency | cut -f1 -d ' ')"
-       " | grep -E '^token'"
-       "|cut -f2 -d':'|tr -d ' '")
-
-token = subprocess.check_output(cmd, stderr=subprocess.STDOUT,
-                                shell=True).decode('utf-8').strip("\n")
-cmd = ('kubectl config view --minify | grep server |'
-       'cut -f 2- -d ":" | tr -d " "')
-server = subprocess.check_output(cmd, stderr=subprocess.STDOUT,
-                                 shell=True).decode('utf-8').strip("\n")
-pod_conn = Pods(token=token, host=server)
-job_conn = Jobs(token=token, host=server)
+pod_conn = Pods()
+job_conn = Jobs()
 
 
 class k8sExecutioner(object):

--- a/plugins/chaos/torpedo_chaos/log_analyzer.py
+++ b/plugins/chaos/torpedo_chaos/log_analyzer.py
@@ -17,17 +17,7 @@ formatter = logging.Formatter(
 stream_handle.setFormatter(formatter)
 LOG.addHandler(stream_handle)
 
-cmd = ("kubectl describe secret -n metacontroller $(kubectl get secrets"
-       " -n metacontroller | grep ^resiliency | cut -f1 -d ' ')"
-       " | grep -E '^token'"
-       "|cut -f2 -d':'|tr -d ' '")
-token = subprocess.check_output(cmd, stderr=subprocess.STDOUT,
-                                shell=True).decode('utf-8').strip("\n")
-cmd = ('kubectl config view --minify | grep server |'
-       'cut -f 2- -d ":" | tr -d " "')
-server = subprocess.check_output(cmd, stderr=subprocess.STDOUT,
-                                 shell=True).decode('utf-8').strip("\n")
-pod_conn = Pods(token=token, host=server)
+pod_conn = Pods()
 
 
 def log_analyzer(log_dir, service_list):


### PR DESCRIPTION
Currently we create kubernetes  client object with fetching Host and Token.

 for Remote cluster it tries to fetch host and token from remote cluster in metacontroller namespace and if thats not present it will fail.

now making change to load_kube_config so we no need to fetch Host and Token.
